### PR TITLE
feat: extract recall_from() as standalone function

### DIFF
--- a/src/alpha_sdk/memories/__init__.py
+++ b/src/alpha_sdk/memories/__init__.py
@@ -9,7 +9,7 @@ Cortex is now fully absorbed into alpha_sdk:
 
 from .cortex import store, search, recent, get, forget, health, close, EmbeddingError
 from .images import create_thumbnail, load_thumbnail_base64, process_inline_image
-from .recall import recall
+from .recall import recall, recall_from
 from .suggest import suggest
 
 __all__ = [
@@ -28,5 +28,6 @@ __all__ = [
     "process_inline_image",
     # Higher-level functions
     "recall",
+    "recall_from",
     "suggest",
 ]


### PR DESCRIPTION
Extracts the core dual-strategy recall logic into a new public `recall_from(text, exclude=None)` function, callable without a session_id. `recall()` is refactored to delegate to it, preserving existing API and seen-cache behavior unchanged. `recall_from` is exported from `alpha_sdk.memories`.

Closes #17

Generated with [Claude Code](https://claude.ai/code)